### PR TITLE
Fix index.js to correctly support MHOutlet device

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,6 @@ module.exports = function (homebridge) {
 
 
 
-ciccio
-
 	/* Try to map Elgato's outlet custom vars */
 	LegrandMyHome.CurrentPowerConsumption = function() {
 		Characteristic.call(this, 'Consumption', 'E863F10D-079E-48FF-8F27-9C2605A29F52');

--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@ module.exports = function (homebridge) {
 
 
 
+ciccio
+
 	/* Try to map Elgato's outlet custom vars */
 	LegrandMyHome.CurrentPowerConsumption = function() {
 		Characteristic.call(this, 'Consumption', 'E863F10D-079E-48FF-8F27-9C2605A29F52');

--- a/index.js
+++ b/index.js
@@ -239,7 +239,7 @@ class MHRelay {
 			.setCharacteristic(Characteristic.SerialNumber, "Address " + this.address);
 
 		switch (this.config.accessory) {
-			case 'MHRelayOutlet':
+			case 'MHOutlet':
 				this.lightBulbService = new Service.Outlet(this.name);
 				break;
 			default:

--- a/index.js
+++ b/index.js
@@ -11,9 +11,6 @@ module.exports = function (homebridge) {
 	UUIDGen = homebridge.hap.uuid;
 
 
-
-ciccio
-
 	/* Try to map Elgato's outlet custom vars */
 	LegrandMyHome.CurrentPowerConsumption = function() {
 		Characteristic.call(this, 'Consumption', 'E863F10D-079E-48FF-8F27-9C2605A29F52');

--- a/index.js
+++ b/index.js
@@ -10,8 +10,6 @@ module.exports = function (homebridge) {
 	Accessory = homebridge.platformAccessory;
 	UUIDGen = homebridge.hap.uuid;
 
-
-
 	/* Try to map Elgato's outlet custom vars */
 	LegrandMyHome.CurrentPowerConsumption = function() {
 		Characteristic.call(this, 'Consumption', 'E863F10D-079E-48FF-8F27-9C2605A29F52');


### PR DESCRIPTION
Ciao Angelo,
I found out that the condition in the CASE clause to check if the device is a lamp or an outlet was wrong. With the fix, devices defined as MHOutlet in config.json now appear correctly as power outlet in HomeKit. I tested it and seems to work well.